### PR TITLE
[FW-537] rtc: use new datetime types

### DIFF
--- a/targets/furi_hal_include/furi_hal_rtc.h
+++ b/targets/furi_hal_include/furi_hal_rtc.h
@@ -32,13 +32,13 @@ void furi_hal_rtc_prepare_for_shutdown(void);
  *
  * @param      datetime  The date time to set
  */
-void furi_hal_rtc_set_datetime(DateTime* datetime);
+void furi_hal_rtc_set_datetime(const DateTimeMs* datetime);
 
 /** Get RTC Date Time
  *
- * @param      datetime  The datetime
+ * @return      The datetime
  */
-void furi_hal_rtc_get_datetime(DateTime* datetime);
+DateTimeMs furi_hal_rtc_get_datetime(void);
 
 /** Get UNIX Timestamp
  *


### PR DESCRIPTION
Use new types from updated datetime library.