### PR TITLE
Fix Resources Re-Build

### DIFF
--- a/site_scons/site_tools/fbt_resources.py
+++ b/site_scons/site_tools/fbt_resources.py
@@ -41,14 +41,15 @@ def __generate_resources_dist_entries(env):
             extra_dist, target_path = extra_dist
 
         if isinstance(extra_dist, Dir):
-            src_target_entries.append(
-                (
-                    extra_dist,
-                    resources_root.Dir(
-                        extra_dist.name if not target_path else target_path
-                    ),
-                )
+            dst_dir = resources_root.Dir(
+                extra_dist.name if not target_path else target_path
             )
+            for res_file in env.GlobRecursive("*", extra_dist):
+                if not isinstance(res_file, File):
+                    continue
+                src_target_entries.append(
+                    (res_file, dst_dir.File(res_file.get_path(extra_dist)))
+                )
         else:
             raise StopError(f"Unsupported extra dist type: {type(extra_dist)}")
 
@@ -70,8 +71,6 @@ def _resources_dist_action(target, source, env):
         if isinstance(src, File):
             os.makedirs(os.path.dirname(dst.path), exist_ok=True)
             shutil.copy(src.path, dst.path)
-        elif isinstance(src, Dir):
-            shutil.copytree(src.path, dst.path, dirs_exist_ok=True)
         else:
             raise StopError(f"Unsupported dist entry type: {type(src)}")
 


### PR DESCRIPTION
> Emitter (line 43-52): Instead of adding the _EXTRA_DIST directory as a single Dir target, it now enumerates all files within it via GlobRecursive and adds them as individual File targets. This eliminates the Dir target that was causing parent-child dependency cycles with overlapping File targets from APPBUILD resources.

> Action (line 70-74): Removed the Dir copy branch (shutil.copytree) since all targets are now File nodes — the os.makedirs + shutil.copy in the File branch handles directory creation and copying.