### PR TITLE
[FW-993] Fix `VS Code` Settings Templates Paths

### DIFF
--- a/.vscode/template/cpptools/c_cpp_properties.json.tmpl
+++ b/.vscode/template/cpptools/c_cpp_properties.json.tmpl
@@ -4,7 +4,7 @@
             "name": "Win32",
             "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc.exe",
             "intelliSenseMode": "gcc-arm",
-            "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
+            "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",
             "cppStandard": "c++20"
         },
@@ -12,7 +12,7 @@
             "name": "Linux",
             "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
-            "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
+            "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",
             "cppStandard": "c++20"
         },
@@ -20,7 +20,7 @@
             "name": "Mac",
             "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
-            "compileCommands": "${workspaceFolder}/build/latest/compile_commands.json",
+            "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",
             "cppStandard": "c++20"
         }

--- a/.vscode/template/launch.json.tmpl
+++ b/.vscode/template/launch.json.tmpl
@@ -11,7 +11,7 @@
         {
             "name": "[{{ probe.name }}] Attach {{ f_target }} {{ "(NoRTOS)" if not rtos_enabled else "" }}",
             "cwd": "${workspaceFolder}",
-            "executable": "./build/latest/firmware.elf",
+            "executable": "{{ fbt_dir }}/build/latest/firmware.elf",
             "request": "attach",
             "type": "cortex-debug",
             "servertype": "openocd",
@@ -34,8 +34,8 @@
             "postAttachCommands": [
                 // "source scripts/debug/flipperversion.py",
                 // "fw-version",
-                "source scripts/debug/flipperapps.py",
-                "fap-set-debug-elf-root build/latest/.extapps"
+                "source {{ fbt_dir }}/scripts/debug/flipperapps.py",
+                "fap-set-debug-elf-root {{ fbt_dir }}/build/latest/.extapps"
             ],
             // "showDevDebugOutput": "raw",
         },

--- a/.vscode/template/settings.json.tmpl
+++ b/.vscode/template/settings.json.tmpl
@@ -15,7 +15,7 @@
     "clangd.path": "${workspaceFolder}/toolchain/current/bin/clangd{{ FBT_PLATFORM_EXECUTABLE_EXT }}",
     "clangd.arguments": [
         "--query-driver=**/arm-none-eabi-*",
-        "--compile-commands-dir=${workspaceFolder}/build/latest",
+        "--compile-commands-dir={{ fbt_dir }}/build/latest",
         "--clang-tidy",
         "--header-insertion=never"
     ]

--- a/scripts/fbt_env_modules/dist/vscode_project.scons
+++ b/scripts/fbt_env_modules/dist/vscode_project.scons
@@ -28,6 +28,7 @@ template_substs = {
     "f_target": firmware_env.subst("${F_TARGET_HW}"),
     "target": firmware_env.subst("${TARGET_HW}"),
     "FWENV": firmware_env,
+    "fbt_dir": Path(Dir("#").abspath).as_posix(),
     "folders": list(
         map(
             lambda x: Path(config_dist_dir.rel_path(x)).as_posix(),

--- a/scripts/fbt_env_modules/dist/vscode_project.scons
+++ b/scripts/fbt_env_modules/dist/vscode_project.scons
@@ -47,6 +47,15 @@ for template_file in vscode_distenv.Glob("#.vscode/template/*.tmpl"):
         )
     )
 
+for template_file in vscode_distenv.Glob("#.vscode/template/${LANG_SERVER}/*.tmpl"):
+    vscode_dist.append(
+        vscode_distenv.TempliteFile(
+            config_dist_dir.File(template_file.name.replace(".tmpl", "")),
+            template_file,
+            SUBST_DICT=template_substs,
+        )
+    )
+
 
 vscode_distenv.Depends(
     vscode_dist, Value((template_substs["f_target"], template_substs["folders"]))


### PR DESCRIPTION
> [!NOTE]
> * [**FW-993**](https://flipper.atlassian.net/browse/FW-993)

* fix debug paths launch.json
* fix `clangd` language server's `compile-commands-dir` path settings.json
* fix `cpptools` language server's paths (also introduces `c_cpp_properties.json`'s template)

> [!IMPORTANT]
> Please, update this submodule in `bsb-firmware` repository after merging.
