### PR TITLE
[FW-1066] Make All Toolchain Template Paths Absolute

### DIFF
--- a/.vscode/template/cpptools/c_cpp_properties.json.tmpl
+++ b/.vscode/template/cpptools/c_cpp_properties.json.tmpl
@@ -2,7 +2,7 @@
     "configurations": [
         {
             "name": "Win32",
-            "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc.exe",
+            "compilerPath": "{{ toolchain_dir }}/current/bin/arm-none-eabi-gcc.exe",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",
@@ -10,7 +10,7 @@
         },
         {
             "name": "Linux",
-            "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc",
+            "compilerPath": "{{ toolchain_dir }}/current/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",
@@ -18,7 +18,7 @@
         },
         {
             "name": "Mac",
-            "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc",
+            "compilerPath": "{{ toolchain_dir }}/current/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",

--- a/.vscode/template/settings.json.tmpl
+++ b/.vscode/template/settings.json.tmpl
@@ -2,9 +2,9 @@
     "workbench.tree.indent": 12,
     "cortex-debug.enableTelemetry": false,
     "cortex-debug.variableUseNaturalFormat": true,
-    "cortex-debug.armToolchainPath": "${workspaceFolder}/toolchain/current/bin",
-    "cortex-debug.openocdPath": "${workspaceFolder}/toolchain/current/bin/openocd",
-    "cortex-debug.gdbPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gdb-py3",
+    "cortex-debug.armToolchainPath": "{{ toolchain_dir }}/current/bin",
+    "cortex-debug.openocdPath": "{{ toolchain_dir }}/current/bin/openocd",
+    "cortex-debug.gdbPath": "{{ toolchain_dir }}/current/bin/arm-none-eabi-gdb-py3",
     "editor.formatOnSave": true,
     "files.associations": {
         "*.scons": "python",
@@ -12,7 +12,7 @@
         "SConstruct": "python",
         "*.fam": "python"
     },
-    "clangd.path": "${workspaceFolder}/toolchain/current/bin/clangd{{ FBT_PLATFORM_EXECUTABLE_EXT }}",
+    "clangd.path": "{{ toolchain_dir }}/current/bin/clangd{{ FBT_PLATFORM_EXECUTABLE_EXT }}",
     "clangd.arguments": [
         "--query-driver=**/arm-none-eabi-*",
         "--compile-commands-dir={{ fbt_dir }}/build/latest",

--- a/scripts/fbt_env_modules/dist/vscode_project.scons
+++ b/scripts/fbt_env_modules/dist/vscode_project.scons
@@ -29,6 +29,7 @@ template_substs = {
     "target": firmware_env.subst("${TARGET_HW}"),
     "FWENV": firmware_env,
     "fbt_dir": Path(Dir("#").abspath).as_posix(),
+    "toolchain_dir": Path(os.environ["FBT_TOOLCHAIN_PATH"], "toolchain").as_posix(),
     "folders": list(
         map(
             lambda x: Path(config_dist_dir.rel_path(x)).as_posix(),


### PR DESCRIPTION
> [!NOTE]
> * [**FW-1066**](https://flipper.atlassian.net/browse/FW-1066)

Replace all of toolchain paths in VS Code dist's templates with absolute ones using `FBT_TOOLCHAIN_PATH`.