### PR TITLE
Fix `clangd` Path To Use `WhereIs`

### DIFF
--- a/.vscode/template/cpptools/c_cpp_properties.json.tmpl
+++ b/.vscode/template/cpptools/c_cpp_properties.json.tmpl
@@ -2,7 +2,7 @@
     "configurations": [
         {
             "name": "Win32",
-            "compilerPath": "{{ toolchain_dir }}/current/bin/arm-none-eabi-gcc.exe",
+            "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc.exe",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",
@@ -10,7 +10,7 @@
         },
         {
             "name": "Linux",
-            "compilerPath": "{{ toolchain_dir }}/current/bin/arm-none-eabi-gcc",
+            "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",
@@ -18,7 +18,7 @@
         },
         {
             "name": "Mac",
-            "compilerPath": "{{ toolchain_dir }}/current/bin/arm-none-eabi-gcc",
+            "compilerPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gcc",
             "intelliSenseMode": "gcc-arm",
             "compileCommands": "{{ fbt_dir }}/build/latest/compile_commands.json",
             "cStandard": "gnu23",

--- a/.vscode/template/settings.json.tmpl
+++ b/.vscode/template/settings.json.tmpl
@@ -2,9 +2,9 @@
     "workbench.tree.indent": 12,
     "cortex-debug.enableTelemetry": false,
     "cortex-debug.variableUseNaturalFormat": true,
-    "cortex-debug.armToolchainPath": "{{ toolchain_dir }}/current/bin",
-    "cortex-debug.openocdPath": "{{ toolchain_dir }}/current/bin/openocd",
-    "cortex-debug.gdbPath": "{{ toolchain_dir }}/current/bin/arm-none-eabi-gdb-py3",
+    "cortex-debug.armToolchainPath": "${workspaceFolder}/toolchain/current/bin",
+    "cortex-debug.openocdPath": "${workspaceFolder}/toolchain/current/bin/openocd",
+    "cortex-debug.gdbPath": "${workspaceFolder}/toolchain/current/bin/arm-none-eabi-gdb-py3",
     "editor.formatOnSave": true,
     "files.associations": {
         "*.scons": "python",

--- a/.vscode/template/settings.json.tmpl
+++ b/.vscode/template/settings.json.tmpl
@@ -12,7 +12,7 @@
         "SConstruct": "python",
         "*.fam": "python"
     },
-    "clangd.path": "{{ toolchain_dir }}/current/bin/clangd{{ FBT_PLATFORM_EXECUTABLE_EXT }}",
+    "clangd.path": "{{ clangd_path }}",
     "clangd.arguments": [
         "--query-driver=**/arm-none-eabi-*",
         "--compile-commands-dir={{ fbt_dir }}/build/latest",

--- a/scripts/fbt_env_modules/dist/vscode_project.scons
+++ b/scripts/fbt_env_modules/dist/vscode_project.scons
@@ -24,12 +24,11 @@ vscode_dist = vscode_distenv.Install(
 probes = list(filter(lambda x: isinstance(x, OpenOCDInterface), INTERFACES.values()))
 
 template_substs = {
-    "FBT_PLATFORM_EXECUTABLE_EXT": ".exe" if os.name == "nt" else "",
     "f_target": firmware_env.subst("${F_TARGET_HW}"),
     "target": firmware_env.subst("${TARGET_HW}"),
     "FWENV": firmware_env,
     "fbt_dir": Path(Dir("#").abspath).as_posix(),
-    "toolchain_dir": Path(os.environ["FBT_TOOLCHAIN_PATH"], "toolchain").as_posix(),
+    "clangd_path": Path(path).as_posix() if (path := firmware_env.WhereIs("clangd")) else "",
     "folders": list(
         map(
             lambda x: Path(config_dist_dir.rel_path(x)).as_posix(),


### PR DESCRIPTION
Drop all toolchain absolute paths from vscode dist. Replace clangd path with use of `WhereIs` (was using `FBT_TOOLCHAIN_PATH`). Drop `FBT_PLATFORM_EXECUTABLE_EXT` value as it's no longer used.