### PR TITLE
Report a full last flash page instead of 0% on an exact page multiple

### DIFF
--- a/scripts/fwsize.py
+++ b/scripts/fwsize.py
@@ -43,7 +43,10 @@ class Main(App):
         PAGE_SIZE = 4096
         binsize = os.path.getsize(self.args.binname)
         pages = math.ceil(binsize / PAGE_SIZE)
-        last_page_state = (binsize % PAGE_SIZE) * 100 / PAGE_SIZE
+        remainder = binsize % PAGE_SIZE
+        # A size that lands exactly on a page boundary fills that page completely,
+        # it does not leave an empty one.
+        last_page_state = 100.0 if binsize and remainder == 0 else remainder * 100 / PAGE_SIZE
         print(
             fg.yellow(
                 f"{os.path.basename(self.args.binname):<11}: {pages:>4} flash pages (last page {last_page_state:.02f}% full)"


### PR DESCRIPTION
`process_bin` reports the last flash page as 0% full when the binary lands exactly on a page boundary:

```python
last_page_state = (binsize % PAGE_SIZE) * 100 / PAGE_SIZE
```

At 4096 bytes the remainder is 0, so it prints "1 flash pages (last page 0.00% full)". That page is completely full, not empty — and a build padded or aligned to a page boundary is a normal thing to hit.

```
size=4095   pages=1   old= 99.98%   new= 99.98%
size=4096   pages=1   old=  0.00%   new=100.00%
size=8192   pages=2   old=  0.00%   new=100.00%
size=8193   pages=3   old=  0.02%   new=  0.02%
```

Every non-boundary size is unchanged. The `binsize and` part keeps a zero-byte file reporting 0 pages / 0.00% rather than claiming a full page that doesn't exist.

Worth noting for scope: the `elf` subcommand is what the build actually calls (`fw_elf.scons`). I couldn't find a `.scons` file that invokes `bin`, so this looks like it only shows up when a developer runs it by hand — it's an argparse-documented entry point ("Dump bin stats"), just not wired in as far as I can tell.
